### PR TITLE
Now needs Moose 9?

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 ## Installation
 
-In order to install this project, execute (Do-it, Ctrl+D) the following script in the Playground of your Moose 8 Image
+In order to install this project, execute (Do-it, Ctrl+D) the following script in the Playground of your Moose 9 Image
 
 ```Smalltalk
 Metacello new


### PR DESCRIPTION
Because Moose 8 says:
This package depends on the following classes:
  RSComposite
You must resolve these dependencies before you will be able to load these definitions: 
  RSComposite>>#color